### PR TITLE
Dropping default Python variant declaration from dockerfile 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/python-3/.devcontainer/base.Dockerfile
 
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT="3.10-bullseye"
+ARG VARIANT
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 # Define the path to the virtualenv to work with

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build the Codespaces container image
-      run: docker build . --file .devcontainer/Dockerfile
+      run: docker build . --file .devcontainer/Dockerfile --build-arg VARIANT="3.8-bullseye"


### PR DESCRIPTION
Dropping default Python variant declaration from dockerfile. Python variant is explicitly declared in devcontainer.json.